### PR TITLE
[31기 김민주] Add : Amenities & Services 페이지 UI 및 기능 구현 완료

### DIFF
--- a/src/pages/Hosting/HostingPages/Amenities/Amenities.js
+++ b/src/pages/Hosting/HostingPages/Amenities/Amenities.js
@@ -1,0 +1,145 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import AmenitiesOption from './AmenitiesOption';
+import CellWifiIcon from '@mui/icons-material/CellWifi';
+import KitchenIcon from '@mui/icons-material/Kitchen';
+import DirectionsCarIcon from '@mui/icons-material/DirectionsCar';
+import PoolIcon from '@mui/icons-material/Pool';
+import HotTubIcon from '@mui/icons-material/HotTub';
+import OutdoorGrillIcon from '@mui/icons-material/OutdoorGrill';
+
+function Amenities({ newStayInfo }) {
+  const [amenities, setAmenities] = useState([]);
+  const [services, setServices] = useState([]);
+
+  const changeAmenityOptions = id => {
+    if (amenities.includes(id)) {
+      let newAmenityOption = amenities.filter(number => number !== id);
+      setAmenities(newAmenityOption);
+    } else {
+      setAmenities([...amenities, id]);
+    }
+  };
+
+  const changeServiceOptions = id => {
+    if (services.includes(id)) {
+      let newServiceOptions = services.filter(number => number !== id);
+      setServices(newServiceOptions);
+    } else {
+      setServices([...services, id]);
+    }
+  };
+
+  const handleOptions = (category, id) => {
+    if (category === 'amenities') {
+      changeAmenityOptions(id);
+    } else if (category === 'services') {
+      changeServiceOptions(id);
+    }
+  };
+
+  newStayInfo.amenities = amenities;
+  newStayInfo.services = services;
+
+  return (
+    <PageContainer>
+      <OptionsContainer>
+        <OptionContainer>
+          <OptionTitle>특별히 내세울 만한 편의시설이 있나요?</OptionTitle>
+          <Options>
+            {AMENITIY_OPTIONS.map(({ id, text, icon, category }) => {
+              return (
+                <AmenitiesOption
+                  key={id}
+                  id={id}
+                  text={text}
+                  icon={icon}
+                  category={category}
+                  handleOptions={handleOptions}
+                  checkArr={amenities}
+                />
+              );
+            })}
+          </Options>
+        </OptionContainer>
+        <OptionContainer>
+          <OptionTitle>다음 인기 편의시설이 있나요?</OptionTitle>
+          <Options>
+            {SERVICE_OPTIONS.map(({ id, text, icon, category }) => {
+              return (
+                <AmenitiesOption
+                  key={id}
+                  id={id}
+                  text={text}
+                  icon={icon}
+                  category={category}
+                  handleOptions={handleOptions}
+                  checkArr={services}
+                />
+              );
+            })}
+          </Options>
+        </OptionContainer>
+      </OptionsContainer>
+    </PageContainer>
+  );
+}
+
+export default Amenities;
+
+const AMENITIY_OPTIONS = [
+  { id: 1, text: '무선 인터넷', icon: <CellWifiIcon />, category: 'amenities' },
+  {
+    id: 2,
+    text: '주방',
+    icon: <KitchenIcon />,
+    category: 'amenities',
+  },
+  {
+    id: 3,
+    text: '주차장',
+    icon: <DirectionsCarIcon />,
+    category: 'amenities',
+  },
+];
+
+const SERVICE_OPTIONS = [
+  { id: 1, text: '수영장', icon: <PoolIcon />, category: 'services' },
+  {
+    id: 2,
+    text: '자쿠지',
+    icon: <HotTubIcon />,
+    category: 'services',
+  },
+  {
+    id: 3,
+    text: '바베큐',
+    icon: <OutdoorGrillIcon />,
+    category: 'services',
+  },
+];
+
+const PageContainer = styled.div`
+  height: 100vh;
+  margin: 0;
+`;
+
+const OptionsContainer = styled.div`
+  margin: 0 auto;
+  padding: 0 50px;
+  transform: translateY(50%);
+`;
+
+const OptionContainer = styled.div`
+  margin-bottom: 20px;
+`;
+
+const OptionTitle = styled.h2`
+  margin-bottom: 15px;
+  padding-left: 8px;
+  font-size: ${({ theme }) => theme.fontSemiMedium};
+`;
+
+const Options = styled.div`
+  display: flex;
+`;

--- a/src/pages/Hosting/HostingPages/Amenities/AmenitiesOption.js
+++ b/src/pages/Hosting/HostingPages/Amenities/AmenitiesOption.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const AmenitiesOption = ({
+  id,
+  text,
+  icon,
+  category,
+  handleOptions,
+  checkArr,
+}) => {
+  return (
+    <Option
+      onClick={() => {
+        handleOptions(category, id);
+      }}
+      id={id}
+      name={category}
+      border={checkArr.includes(id) ? 'black' : '#dddddd'}
+    >
+      <OptionIconContainer>{icon}</OptionIconContainer>
+      <OptionText>{text}</OptionText>
+    </Option>
+  );
+};
+
+export default AmenitiesOption;
+
+const Option = styled.div`
+  ${({ theme }) => theme.flexBox('column', 'center', 'space-between')}
+  flex-basis: calc(33%);
+  margin: 0 8px 16px 8px;
+  padding: 40px 6px;
+  border: 2px solid ${({ border }) => border};
+  border-radius: 7px;
+`;
+
+const OptionIconContainer = styled.div`
+  margin-bottom: 10px;
+`;
+
+const OptionText = styled.div`
+  font-size: ${({ theme }) => theme.fontMicro};
+`;

--- a/src/pages/Hosting/HostingRouter.js
+++ b/src/pages/Hosting/HostingRouter.js
@@ -6,6 +6,7 @@ import HostingNav from './HostingComponents/HostingNav';
 import StayType from './HostingPages/StayType';
 import SearchForm from './HostingPages/Location/SearchForm';
 import FloorPlan from './HostingPages/FloorPlan/FloorPlan';
+import Amenities from './HostingPages/Amenities/Amenities';
 
 const HostingRouter = () => {
   const navigate = useNavigate();
@@ -71,6 +72,10 @@ const HostingRouter = () => {
           <Route
             path="/floor-plan"
             element={<FloorPlan newStayInfo={newStayInfo} />}
+          />
+          <Route
+            path="/amenities"
+            element={<Amenities newStayInfo={newStayInfo} />}
           />
         </Routes>
         <HostingFooter


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- hosting 기능 중 Amenities & Service 옵션 페이지 UI 및 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
### 1. 유저가 선택한 옵션 정보 배열 형태로 저장 후 로컬스토리지에 저장
 - amenities와 services array가 빈 배열로 초기화 되어 있으며, 유저가 각각의 카테고리에서 선택한 옵션이 해당 카테고리의 배열에 저장됩니다.
 - 만약에 유저가 이미 선택한 옵션을 삭제하기 원할 때, 박스를 한번 더 클릭하면 해당 옵션이 filter되어 해당 카테고리의 배열에서 삭제됩니다.
 - 최종적으로 '다음' 버튼 클릭시 유저가 선택한 옵션이 로컬스토리지에 저장됩니다.

### 2. 유저 선택 옵션 UI로 보여주기
 - 유저가 옵션을 클릭했을 때, 클릭한 버튼의 id가 배열에 이미 포함되어 있는지 확인합니다. (유저가 선택했던 옵션인지 확인)
 - 배열에 포함되어 있지 않다면, 즉 유저가 새롭게 추가하려는 옵션이면 해당 옵션의 border 색깔을 바꾸어 표시해 줍니다.
 - 유저가 이미 추가했던 옵션을 삭제하려는 경우, 카테고리에서 해당 옵션의 id가 사라지므로 border 색깔도 원래의 색으로 변경되어, 유저에게 클릭한 옵션이 해제되었음을 알려줍니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 부모에서 map을 돌린 자식들을 관리하기 위해서는 부모에서 state 관리를 해줘야 하는 점을 다시 한번 깨닫게 되었습니다.

- filter method 사용시, arr.filter를 한 후, 바로 arr를 출력해보면 원하는 조건에 맞는 새로운 배열이 출력될 것이라고 생각했지만, 잘못된 생각이었습니다. arr에는 변화가 없고 arr.filter를 통해 만들어지는 새로운 배열을 다른 곳에 저장한 후, 만들어 놓았던 state에 저장해 주어야 했습니다. 늘 헷갈렸던 부분인데, 다시 한 번 짚고 넘어갈 수 있었습니다.

- props전달 시, 같은 변수에 다른 값을 전달함으로써, 다른 array 두 개를 동일하게 조작할 수 있는 것을 알게되었습니다. 한 부모컴포넌트에서 자식컴포넌트에게 props를 넘겨줄 때, 'checkArr={amenities}', 'checkArr={services}'로 넘겨주고 자식컴포넌트에서는 'checkArr'로 받아 해당 값을 true/false 유효성 검사 로직에 넣어주었는데 컴포넌트와 props의 편리함을 한번 더 느낄 수 있었습니다. 

<br />

## :: 기타 질문 및 특이 사항
-  옵션 선택시 해당 옵션의 style을 변경해주기 위해서 부모에서 만든 배열을 자식으로 넘겨줬더니, 렌더링이 버튼의 개수만큼 재실행됩니다. 외관상 볼 때는 큰 문제는 없지만, 제가 만든 방법대로 설계할 경우 옵션이 늘어나게 되면 성능상 좋지 않을 것 같아 더 좋은 방법이 있는지 문의드립니다 :) 
